### PR TITLE
fix: #52, template files input stop

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -125,7 +125,7 @@ class LuhmanSettingTab extends PluginSettingTab {
           .onChange(async (value) => {
             this.plugin.settings.templateFile = value;
             await this.plugin.saveSettings();
-            this.display();
+            // this.display();
           });
       });
 


### PR DESCRIPTION
This acts as a fix for the bug in #52. It seems that the issue came from this.display() triggering on every change in the input, so I just commented it out. A side effect is that making changes in the input no longer displays new options, but it's not noticeable in practice. 